### PR TITLE
Don't set var keyword if namespace contains a dot

### DIFF
--- a/tasks/json.js
+++ b/tasks/json.js
@@ -23,7 +23,7 @@ module.exports = function (grunt) {
         var basename;
         var filename;
 
-        return 'var ' + namespace + ' = ' + namespace + ' || {};' + files.map(function (filepath) {
+        return namespace.indexOf('.') === -1 ? 'var ' : '' + namespace + ' = ' + namespace + ' || {};' + files.map(function (filepath) {
             basename = path.basename(filepath, '.json');
             filename = (includePath) ? processName(filepath) : processName(basename);
             return '\n' + namespace + '["' + filename + '"] = ' + grunt.file.read(filepath) + ';';


### PR DESCRIPTION
I've been using MyObject.myjson as namespace, but a var keyword was preceded by. This fix sets a var key word only if namspace doesn't contain a dot